### PR TITLE
feat: implement HTTP-style request parser

### DIFF
--- a/lua/restman/parser/http.lua
+++ b/lua/restman/parser/http.lua
@@ -1,0 +1,107 @@
+local M = {}
+
+---HTTP request method names
+local HTTP_METHODS = {
+  "GET",
+  "POST",
+  "PUT",
+  "PATCH",
+  "DELETE",
+  "HEAD",
+  "OPTIONS",
+  "CONNECT",
+  "TRACE",
+}
+
+---Pattern to match HTTP-style prefix: METHOD URL
+---Supports quoted or bare URLs, case-insensitive methods
+local PATTERN = "^(%S+)%s+(.+)$"
+
+---@class Request
+---@field method string HTTP method (uppercase)
+---@field url string Request URL
+---@field headers table<string, string> Request headers (empty by default)
+---@field body? string Request body (nil by default)
+---@field source RequestSource Source location info
+
+---@class RequestSource
+---@field file string Source file path
+---@field line number Source line number (1-indexed)
+
+---Strip quotes from a string if wrapped in single or double quotes
+---@param str string String to strip quotes from
+---@return string String with quotes removed if present
+local function strip_quotes(str)
+  local trimmed = vim.trim(str)
+  -- Check for double quotes
+  if string.sub(trimmed, 1, 1) == '"' and string.sub(trimmed, -1) == '"' then
+    return string.sub(trimmed, 2, -2)
+  end
+  -- Check for single quotes
+  if string.sub(trimmed, 1, 1) == "'" and string.sub(trimmed, -1) == "'" then
+    return string.sub(trimmed, 2, -2)
+  end
+  return trimmed
+end
+
+---Check if a string is a valid HTTP method (case-insensitive)
+---@param method_str string String to check
+---@return boolean True if valid HTTP method
+local function is_valid_method(method_str)
+  local upper = string.upper(method_str)
+  for _, method in ipairs(HTTP_METHODS) do
+    if upper == method then
+      return true
+    end
+  end
+  return false
+end
+
+---Parse a line as HTTP-style request (METHOD URL)
+---Returns nil if line does not match the pattern
+---Accepts:
+--- - GET https://api.com/users
+--- - POST /users
+--- - delete '/api/x'
+--- - # GET /api/v1/users/42 (comment lines are still parsed if pattern matches)
+---
+---@param line string Line to parse
+---@param line_number number Line number (1-indexed)
+---@param file_path string Source file path
+---@return Request|nil Parsed request or nil if no match
+function M.parse(line, line_number, file_path)
+  if not line or line == "" then
+    return nil
+  end
+
+  -- Strip leading comment marker (#) to support comment lines with patterns
+  local stripped = line:gsub("^%s*#%s*", "", 1)
+
+  -- Try to match METHOD URL pattern
+  local method, url = stripped:match(PATTERN)
+  if not method or not url then
+    return nil
+  end
+
+  -- Validate that method is an HTTP verb
+  if not is_valid_method(method) then
+    return nil
+  end
+
+  -- Strip quotes from URL if present
+  local clean_url = strip_quotes(url)
+
+  -- Return parsed request structure
+  return {
+    method = string.upper(method),
+    url = clean_url,
+    headers = {},
+    body = nil,
+    source = {
+      file = file_path,
+      line = line_number,
+    },
+  }
+end
+
+return M

--- a/lua/restman/parser/http_test.lua
+++ b/lua/restman/parser/http_test.lua
@@ -1,0 +1,100 @@
+-- Manual test file for HTTP parser
+-- Run with: :luafile lua/restman/parser/http_test.lua
+-- Or: nvim --headless -c "luafile %"
+
+-- Add project root to package path
+local project_root = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":h:h:h:h")
+package.path = project_root .. "/lua/?.lua;" .. project_root .. "/lua/?/init.lua;" .. package.path
+
+local http_parser = require("restman.parser.http")
+
+local function test_case(description, line, expected)
+  local result = http_parser.parse(line, 1, "test.http")
+  local passed = true
+
+  if expected == nil then
+    if result ~= nil then
+      passed = false
+      print("❌ " .. description .. " | Expected nil, got: " .. vim.inspect(result))
+    else
+      print("✅ " .. description)
+    end
+  else
+    if result == nil then
+      passed = false
+      print("❌ " .. description .. " | Got nil")
+    elseif result.method ~= expected.method or result.url ~= expected.url then
+      passed = false
+      print("❌ " .. description .. " | Expected: " .. vim.inspect(expected) .. ", Got: " .. vim.inspect(result))
+    else
+      print("✅ " .. description)
+    end
+  end
+
+  return passed
+end
+
+print("\n=== HTTP Parser Tests ===\n")
+
+local all_passed = true
+
+-- Acceptance criteria tests
+all_passed = test_case("GET with absolute URL", "GET https://api.com/users",
+  { method = "GET", url = "https://api.com/users" }) and all_passed
+
+all_passed = test_case("POST with relative URL", "POST /users",
+  { method = "POST", url = "/users" }) and all_passed
+
+all_passed = test_case("DELETE lowercase with single quotes", "delete '/api/x'",
+  { method = "DELETE", url = "/api/x" }) and all_passed
+
+all_passed = test_case("Comment line with pattern", "# GET /api/v1/users/42",
+  { method = "GET", url = "/api/v1/users/42" }) and all_passed
+
+all_passed = test_case("Comment line with spaces", "#  POST  /api/users",
+  { method = "POST", url = "/api/users" }) and all_passed
+
+all_passed = test_case("Invalid line returns nil", "not an http request", nil) and all_passed
+
+-- Additional edge cases
+all_passed = test_case("PUT with double quotes", 'PUT "https://api.com/update"',
+  { method = "PUT", url = "https://api.com/update" }) and all_passed
+
+all_passed = test_case("PATCH without quotes", "PATCH /api/v1/resource",
+  { method = "PATCH", url = "/api/v1/resource" }) and all_passed
+
+all_passed = test_case("HEAD method", "HEAD /api/status",
+  { method = "HEAD", url = "/api/status" }) and all_passed
+
+all_passed = test_case("OPTIONS method", "OPTIONS /api/options",
+  { method = "OPTIONS", url = "/api/options" }) and all_passed
+
+all_passed = test_case("CONNECT method", "CONNECT proxy.example.com:8080",
+  { method = "CONNECT", url = "proxy.example.com:8080" }) and all_passed
+
+all_passed = test_case("TRACE method", "TRACE /api/trace",
+  { method = "TRACE", url = "/api/trace" }) and all_passed
+
+all_passed = test_case("Empty string returns nil", "", nil) and all_passed
+
+all_passed = test_case("Only method without URL returns nil", "GET", nil) and all_passed
+
+-- Verify source structure
+local result = http_parser.parse("GET /test", 42, "/path/to/file.http")
+if result and result.source and result.source.file == "/path/to/file.http" and result.source.line == 42 then
+  print("✅ Source structure (1-indexed line, absolute path)")
+else
+  print("❌ Source structure")
+  all_passed = false
+end
+
+-- Verify headers and body defaults
+local defaults = http_parser.parse("GET /test", 1, "test.http")
+if defaults and type(defaults.headers) == "table" and defaults.body == nil then
+  print("✅ Default headers = {}, body = nil")
+else
+  print("❌ Default headers/body")
+  all_passed = false
+end
+
+print("\n=== " .. (all_passed and "ALL TESTS PASSED ✅" or "SOME TESTS FAILED ❌") .. " ===\n")


### PR DESCRIPTION
## Summary
- Add HTTP-style request parser (`METHOD URL` pattern)
- Support all 9 HTTP methods (GET, POST, PUT, PATCH, DELETE, HEAD, OPTIONS, CONNECT, TRACE)
- Handle quoted (single/double) and bare URLs
- Parse comment lines starting with `#`
- Add comprehensive test suite (16/16 passing)

## Acceptance Criteria
- ✅ `GET https://api.com/users` → `{ method="GET", url="https://api.com/users" }`
- ✅ `POST /users` → `{ method="POST", url="/users" }`
- ✅ `delete '/api/x'` → `{ method="DELETE", url="/api/x" }`
- ✅ `# GET /api/v1/users/42` → parses successfully
- ✅ Invalid lines → return `nil`
- ✅ `source.line` is 1-indexed

## Test Plan
- Manual test suite verified with `nvim --headless`
- All 16 test cases passing

## Issue
closes #2