### PR TITLE
feat: Parser — Framework route DSL (Rails/Sinatra/Express)

### DIFF
--- a/lua/restman/parser/dsl.lua
+++ b/lua/restman/parser/dsl.lua
@@ -1,0 +1,171 @@
+local util = require("restman.parser.util")
+local M = {}
+
+---HTTP request method names (lowercase for DSL matching)
+local DSL_METHODS = {
+  "get",
+  "post",
+  "put",
+  "patch",
+  "delete",
+  "head",
+  "options",
+}
+
+---Pattern to match Rails/Sinatra DSL: method 'url' or method "url" or method `url`
+---Examples: get '/users', post "/login", delete `items/:id`
+local RAILS_PATTERN = "^%s*([%w]+)[%s%(]+(['\"`])([^%'\"`]+)%2"
+
+---Pattern to match Express DSL: obj.method('url') or obj.method("url") or obj.method(`url`)
+---Examples: router.get('/x'), app.post("/y"), api.delete(`z`)
+local EXPRESS_PATTERN_SINGLE = "^%s*([%w%.]+)[%.]([%w]+)%((['])([^']+)%3%)"
+local EXPRESS_PATTERN_DOUBLE = "^%s*([%w%.]+)[%.]([%w]+)%(([\"])([^\"]+)%3%)"
+local EXPRESS_PATTERN_BACKTICK = "^%s*([%w%.]+)[%.]([%w]+)%((`)([^`]+)%3%)"
+
+---@class Request
+---@field method string HTTP method (uppercase)
+---@field url string Request URL
+---@field headers table<string, string> Request headers (empty by default)
+---@field body? string Request body (nil by default)
+---@field source RequestSource Source location info
+
+---@class RequestSource
+---@field file string Source file path
+---@field line number Source line number (1-indexed)
+
+---Check if a string is a valid DSL method (case-insensitive)
+---@param method_str string String to check
+---@return boolean True if valid DSL method
+local function is_valid_dsl_method(method_str)
+  local lower = string.lower(method_str)
+  for _, method in ipairs(DSL_METHODS) do
+    if lower == method then
+      return true
+    end
+  end
+  return false
+end
+
+---Parse a line as Rails/Sinatra DSL route
+---Returns nil if line does not match the pattern
+---
+---@param line string Line to parse
+---@param line_number number Line number (1-indexed)
+---@param file_path string Source file path
+---@return Request|nil Parsed request or nil if no match
+local function parse_rails_dsl(line, line_number, file_path)
+  local method, _, url = line:match(RAILS_PATTERN)
+  if not method or not url then
+    return nil
+  end
+
+  -- Validate that method is exactly an HTTP verb (word boundary)
+  -- This prevents matching getUser, get_user, etc.
+  if not is_valid_dsl_method(method) then
+    return nil
+  end
+
+  -- Strip quotes from URL if present
+  local clean_url = util.strip_quotes(url)
+
+  -- Validate URL is not empty
+  if not clean_url or clean_url == "" then
+    return nil
+  end
+
+  -- Return parsed request structure
+  return {
+    method = string.upper(method),
+    url = clean_url,
+    headers = {},
+    body = nil,
+    source = {
+      file = file_path,
+      line = line_number,
+    },
+  }
+end
+
+---Parse a line as Express DSL route
+---Returns nil if line does not match the pattern
+---
+---@param line string Line to parse
+---@param line_number number Line number (1-indexed)
+---@param file_path string Source file path
+---@return Request|nil Parsed request or nil if no match
+local function parse_express_dsl(line, line_number, file_path)
+  -- Try single quote pattern first
+  local obj, method, _, url = line:match(EXPRESS_PATTERN_SINGLE)
+  -- Try double quote pattern
+  if not obj or not method or not url then
+    obj, method, _, url = line:match(EXPRESS_PATTERN_DOUBLE)
+  end
+  -- Try backtick pattern
+  if not obj or not method or not url then
+    obj, method, _, url = line:match(EXPRESS_PATTERN_BACKTICK)
+  end
+
+  if not obj or not method or not url then
+    return nil
+  end
+
+  -- Validate that method is exactly an HTTP verb (word boundary)
+  if not is_valid_dsl_method(method) then
+    return nil
+  end
+
+  -- Strip quotes from URL if present
+  local clean_url = util.strip_quotes(url)
+
+  -- Validate URL is not empty
+  if not clean_url or clean_url == "" then
+    return nil
+  end
+
+  -- Return parsed request structure
+  return {
+    method = string.upper(method),
+    url = clean_url,
+    headers = {},
+    body = nil,
+    source = {
+      file = file_path,
+      line = line_number,
+    },
+  }
+end
+
+---Parse a line as DSL route (Rails/Sinatra or Express)
+---Returns nil if line does not match any known pattern
+---
+---Accepts:
+--- - Rails/Sinatra: get '/users', post "/login", delete `items/:id`
+--- - Express: router.get('/x'), app.post("/y"), api.delete(`z`)
+---
+---Word boundary enforcement: getUser('/x') → nil (not a verb)
+---
+---@param line string Line to parse
+---@param line_number number Line number (1-indexed)
+---@param file_path string Source file path
+---@return Request|nil Parsed request or nil if no match
+function M.parse(line, line_number, file_path)
+  if not line or line == "" then
+    return nil
+  end
+
+  -- Try Rails/Sinatra pattern first
+  local result = parse_rails_dsl(line, line_number, file_path)
+  if result then
+    return result
+  end
+
+  -- Try Express pattern
+  result = parse_express_dsl(line, line_number, file_path)
+  if result then
+    return result
+  end
+
+  return nil
+end
+
+return M

--- a/lua/restman/parser/dsl_test.lua
+++ b/lua/restman/parser/dsl_test.lua
@@ -1,0 +1,237 @@
+-- Add project root to package.path
+local project_root = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":h:h:h:h")
+package.path = project_root .. "/lua/?.lua;" .. project_root .. "/lua/?/init.lua;" .. package.path
+
+local parser = require("restman.parser.dsl")
+
+local total_tests = 0
+local passed_tests = 0
+
+---Test helper function
+local function test_case(description, test_fn)
+  total_tests = total_tests + 1
+  local success, err = pcall(test_fn)
+  if success then
+    passed_tests = passed_tests + 1
+    print("✅ " .. description)
+  else
+    print("❌ " .. description .. ": " .. tostring(err))
+  end
+end
+
+---Assertion helpers
+local function assert_eq(actual, expected, context)
+  if actual ~= expected then
+    error(string.format("%s\n  Expected: %s\n  Got: %s", context, vim.inspect(expected), vim.inspect(actual)))
+  end
+end
+
+local function assert_neq(actual, unexpected, context)
+  if actual == unexpected then
+    error(string.format("%s\n  Should not equal: %s\n  Got: %s", context, vim.inspect(unexpected), vim.inspect(actual)))
+  end
+end
+
+local function assert_nil(value, context)
+  if value ~= nil then
+    error(string.format("%s\n  Expected: nil\n  Got: %s", context, vim.inspect(value)))
+  end
+end
+
+-- ============================================================================
+-- Acceptance Criteria Tests
+-- ============================================================================
+
+-- Test 1: get '/articles/:slug/comments/:comment_id' → GET
+test_case("Rails DSL: get with path params", function()
+  local result = parser.parse("get '/articles/:slug/comments/:comment_id'", 1, "test.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "GET", "method")
+  assert_eq(result.url, "/articles/:slug/comments/:comment_id", "url")
+end)
+
+-- Test 2: post '/login' → POST
+test_case("Rails DSL: post with single quotes", function()
+  local result = parser.parse("post '/login'", 1, "test.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "POST", "method")
+  assert_eq(result.url, "/login", "url")
+end)
+
+-- Test 3: router.delete('/items/:id') → DELETE
+test_case("Express DSL: router.delete with path param", function()
+  local result = parser.parse("router.delete('/items/:id')", 1, "test.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "DELETE", "method")
+  assert_eq(result.url, "/items/:id", "url")
+end)
+
+-- Test 4: app.patch("/users/:id") → PATCH
+test_case("Express DSL: app.patch with double quotes", function()
+  local result = parser.parse("app.patch(\"/users/:id\")", 1, "test.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "PATCH", "method")
+  assert_eq(result.url, "/users/:id", "url")
+end)
+
+-- Test 5: getUser('/u') → nil (not a verb)
+test_case("Word boundary: getUser should not match", function()
+  local result = parser.parse("getUser('/u')", 1, "test.js")
+  assert_nil(result, "should not match getUser")
+end)
+
+-- Test 6: get_user('/x') → nil (not a verb)
+test_case("Word boundary: get_user should not match", function()
+  local result = parser.parse("get_user('/x')", 1, "test.rb")
+  assert_nil(result, "should not match get_user")
+end)
+
+-- ============================================================================
+-- Additional DSL Pattern Tests
+-- ============================================================================
+
+test_case("Rails DSL: put with double quotes", function()
+  local result = parser.parse("put \"/items/:id\"", 1, "test.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "PUT", "method")
+  assert_eq(result.url, "/items/:id", "url")
+end)
+
+test_case("Rails DSL: delete with backticks", function()
+  local result = parser.parse("delete `/api/v1/users/:id`", 1, "test.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "DELETE", "method")
+  assert_eq(result.url, "/api/v1/users/:id", "url")
+end)
+
+test_case("Express DSL: api.get with nested path", function()
+  local result = parser.parse("api.get('/articles/:slug/comments/:comment_id')", 1, "test.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "GET", "method")
+  assert_eq(result.url, "/articles/:slug/comments/:comment_id", "url")
+end)
+
+test_case("Express DSL: router.post with double quotes", function()
+  local result = parser.parse("router.post(\"/login\")", 1, "test.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "POST", "method")
+  assert_eq(result.url, "/login", "url")
+end)
+
+test_case("Express DSL: app.put with backticks", function()
+  local result = parser.parse("app.put(`/items/:id`)", 1, "test.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "PUT", "method")
+  assert_eq(result.url, "/items/:id", "url")
+end)
+
+test_case("Express DSL: expressRouter.patch", function()
+  local result = parser.parse("expressRouter.patch('/users/:id')", 1, "test.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.method, "PATCH", "method")
+  assert_eq(result.url, "/users/:id", "url")
+end)
+
+-- ============================================================================
+-- Edge Cases and False Positives
+-- ============================================================================
+
+test_case("Rails DSL: with leading whitespace", function()
+  local result = parser.parse("  get '/users'", 1, "test.rb")
+  assert_neq(result, nil, "should match with leading space")
+  assert_eq(result.method, "GET", "method")
+end)
+
+test_case("Rails DSL: with tab indentation", function()
+  local result = parser.parse("\tget '/users'", 1, "test.rb")
+  assert_neq(result, nil, "should match with tab")
+  assert_eq(result.method, "GET", "method")
+end)
+
+test_case("Rails DSL: get without parentheses", function()
+  local result = parser.parse("get '/users'", 1, "test.rb")
+  assert_neq(result, nil, "should match without parens")
+  assert_eq(result.method, "GET", "method")
+end)
+
+test_case("Rails DSL: get with parentheses", function()
+  local result = parser.parse("get('/users')", 1, "test.rb")
+  assert_neq(result, nil, "should match with parens")
+  assert_eq(result.method, "GET", "method")
+end)
+
+test_case("Express DSL: with leading whitespace", function()
+  local result = parser.parse("  router.get('/users')", 1, "test.js")
+  assert_neq(result, nil, "should match with leading space")
+  assert_eq(result.method, "GET", "method")
+end)
+
+test_case("Word boundary: GetRequest should not match", function()
+  local result = parser.parse("GetRequest('/x')", 1, "test.js")
+  assert_nil(result, "should not match GetRequest")
+end)
+
+test_case("Word boundary: getting should not match", function()
+  local result = parser.parse("getting '/data'", 1, "test.rb")
+  assert_nil(result, "should not match getting")
+end)
+
+test_case("Empty line should not match", function()
+  local result = parser.parse("", 1, "test.rb")
+  assert_nil(result, "should not match empty line")
+end)
+
+test_case("Nil input should not match", function()
+  local result = parser.parse(nil, 1, "test.rb")
+  assert_nil(result, "should not match nil")
+end)
+
+-- ============================================================================
+-- Source Information Tests
+-- ============================================================================
+
+test_case("Source info: file and line should be preserved", function()
+  local result = parser.parse("get '/users'", 42, "routes.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.source.file, "routes.rb", "source file")
+  assert_eq(result.source.line, 42, "source line")
+end)
+
+test_case("Source info: Express should preserve source", function()
+  local result = parser.parse("app.get('/x')", 99, "api.js")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.source.file, "api.js", "source file")
+  assert_eq(result.source.line, 99, "source line")
+end)
+
+-- ============================================================================
+-- Response Structure Tests
+-- ============================================================================
+
+test_case("Response structure: should have empty headers", function()
+  local result = parser.parse("get '/users'", 1, "test.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(type(result.headers), "table", "headers should be table")
+  assert_eq(vim.tbl_count(result.headers), 0, "headers should be empty")
+end)
+
+test_case("Response structure: body should be nil", function()
+  local result = parser.parse("get '/users'", 1, "test.rb")
+  assert_neq(result, nil, "should match")
+  assert_eq(result.body, nil, "body should be nil")
+end)
+
+-- ============================================================================
+-- Print Summary
+-- ============================================================================
+
+print("\n" .. string.rep("=", 60))
+print("DSL Parser Test Results")
+print(string.rep("=", 60))
+print(string.format("Passed: %d/%d tests", passed_tests, total_tests))
+if passed_tests == total_tests then
+  print("✅ All tests passed!")
+else
+  print(string.format("❌ %d test(s) failed", total_tests - passed_tests))
+end
+print(string.rep("=", 60))

--- a/lua/restman/parser/init.lua
+++ b/lua/restman/parser/init.lua
@@ -1,10 +1,11 @@
 -- Parser module
--- Integrates HTTP-style and cURL parsers
+-- Integrates HTTP-style, DSL, and cURL parsers
 
 local M = {}
 
 -- Load individual parsers
 local http_parser = require("restman.parser.http")
+local dsl_parser = require("restman.parser.dsl")
 local curl_parser = require("restman.parser.curl")
 
 -- Parser registry for future extensibility
@@ -12,8 +13,19 @@ local PARSERS = {
   {
     name = "http",
     ---@diagnostic disable-next-line: duplicate-doc-field
-    parse = function(line, line_number, file_path)
+    parse = function(lines_block, line_number, file_path)
+      -- Single-line parser: extract first line from block
+      local line = type(lines_block) == "table" and lines_block[1] or lines_block
       return http_parser.parse(line, line_number, file_path)
+    end,
+  },
+  {
+    name = "dsl",
+    ---@diagnostic disable-next-line: duplicate-doc-field
+    parse = function(lines_block, line_number, file_path)
+      -- Single-line parser: extract first line from block
+      local line = type(lines_block) == "table" and lines_block[1] or lines_block
+      return dsl_parser.parse(line, line_number, file_path)
     end,
   },
   {

--- a/specs/issues/004-parser-dsl.md
+++ b/specs/issues/004-parser-dsl.md
@@ -1,6 +1,6 @@
 ## **Status:**
 - Review: Approved
-- PR: Approved
+- PR: Draft
 
 ## Metadata
 - **Title:** Parser — Framework route DSL (Rails/Sinatra/Express)


### PR DESCRIPTION
## Summary
- Add DSL route parser for Rails/Sinatra/Express patterns
- Support HTTP methods: get|post|put|patch|delete|head|options
- Match patterns like `get '/users'`, `router.post('/login')`, `api.delete('/items/:id')`
- Word boundary enforcement to prevent false matches (getUser, get_user)
- 25 unit tests covering all acceptance criteria

## Test plan
- [x] All 25 unit tests pass
- [x] Integration test with HTTP, DSL, and cURL parsers
- [x] Syntax validation with luac

## Issue
closes #4