### PR TITLE
feat: implement parser directives module (#5)

### DIFF
--- a/lua/restman/parser/directives.lua
+++ b/lua/restman/parser/directives.lua
@@ -1,0 +1,308 @@
+-- Parser for @restman.* comment directives
+-- Scans comment block above request line to extract directives
+--
+-- Example:
+--   -- @restman.body { "name": "Alice" }
+--   -- @restman.header X-Trace-Id: abc-123
+--   POST http://localhost:3000/users
+--
+-- Supported directives:
+--   @restman.body     — JSON body (single or multi-line)
+--   @restman.header   — Add header (Key: Value format)
+--   @restman.query    — Add query param (key=value format)
+--   @restman.form     — Add form param (key=value format)
+
+local M = {}
+
+-- Constants
+-- Hard limit from spec: scan up to 20 lines above request (specs/issues/005-parser-directives.md line 22)
+local MAX_SCAN_LINES = 20
+
+-- Directive patterns
+local PATTERN_BODY = "^@restman%.body%s*(.*)"
+local PATTERN_HEADER = "^@restman%.header%s+([^:]+):%s*(.*)"
+local PATTERN_QUERY = "^@restman%.query%s+([^=]+)=(.*)"
+local PATTERN_FORM = "^@restman%.form%s+([^=]+)=(.*)"
+
+-- Comment prefix patterns
+local COMMENT_PREFIXES = {
+  "^%s*%/%/",  -- // (JS)
+  "^%s*#",     -- # (Python/Ruby)
+  "^%s*%-%-",  -- -- (Lua)
+  "^%s*/%*",   -- /* (C block start)
+  "^%s*%*",    -- * (C block middle)
+}
+
+---Check if a string is blank (whitespace only)
+---@param str string String to check
+---@return boolean True if blank
+local function is_blank(str)
+  return str:match("^%s*$") ~= nil
+end
+
+---Trim whitespace from both ends of a string
+---@param str string String to trim
+---@return string Trimmed string
+local function trim(str)
+  return vim.trim(str)
+end
+
+---@class Directives
+---@field body? table|string Parsed body as table (if JSON) or raw string
+---@field headers? table<string, string> Headers from directives
+---@field query? table<string, string> Query parameters
+---@field form? table<string, string> Form-urlencoded parameters
+
+---Strip comment prefix from a line
+---Returns the stripped line (trimmed), or nil if not a comment
+---@param line string Line to strip
+---@return string|nil Stripped line or nil if no comment prefix
+local function strip_comment_prefix(line)
+  if not line or line == "" then
+    return nil
+  end
+
+  -- Try each comment prefix pattern
+  for _, pattern in ipairs(COMMENT_PREFIXES) do
+    local stripped = line:gsub(pattern, "", 1)
+    if stripped ~= line then
+      return trim(stripped)
+    end
+  end
+
+  -- No comment prefix found
+  return nil
+end
+
+---Parse @restman.body directive with multi-line support
+---Accumulates lines until valid JSON is found
+---@param comment_lines string[] All comment lines (with prefixes stripped)
+---@param start_idx number Starting index in comment_lines array
+---@return table|string|nil body Parsed body (table if JSON, string if raw)
+---@return number next_idx Next index to process
+local function parse_body_directive(comment_lines, start_idx)
+  if start_idx > #comment_lines then
+    return nil, start_idx
+  end
+
+  local first_line = comment_lines[start_idx]
+  local match = first_line:match(PATTERN_BODY)
+
+  if not match then
+    return nil, start_idx
+  end
+
+  local first_content = trim(match)
+
+  -- If first line has content, try to parse it
+  if first_content ~= "" then
+    local success, decoded = pcall(vim.json.decode, first_content)
+    if success then
+      return decoded, start_idx + 1
+    end
+  end
+
+  -- Accumulate additional lines for multi-line JSON
+  local accumulated = { first_content }
+  local idx = start_idx + 1
+
+  while idx <= #comment_lines do
+    local next_line_raw = comment_lines[idx]
+
+    -- Stop at blank line
+    if is_blank(next_line_raw) then
+      break
+    end
+
+    -- Stop at new directive
+    if next_line_raw:match("^@restman%..") then
+      break
+    end
+
+    table.insert(accumulated, next_line_raw)
+    idx = idx + 1
+
+    -- Try to parse accumulated content
+    local full_content = table.concat(accumulated, "")
+    local success, decoded = pcall(vim.json.decode, full_content)
+
+    if success then
+      return decoded, idx
+    end
+  end
+
+  -- If we get here, try to use accumulated content as-is
+  local full_content = table.concat(accumulated, "")
+  full_content = trim(full_content)
+
+  if full_content ~= "" then
+    -- Try one more JSON parse
+    local success, decoded = pcall(vim.json.decode, full_content)
+    if success then
+      return decoded, idx
+    end
+    -- Return raw string
+    return full_content, idx
+  end
+
+  return nil, start_idx + 1
+end
+
+---Parse @restman.header directive
+---@param line string Line to parse (with prefix stripped)
+---@return string|nil key Header key
+---@return string|nil value Header value
+local function parse_header_directive(line)
+  local key, value = line:match(PATTERN_HEADER)
+  if key and value then
+    return trim(key), trim(value)
+  end
+  return nil, nil
+end
+
+---Parse @restman.query directive
+---@param line string Line to parse (with prefix stripped)
+---@return string|nil key Query key
+---@return string|nil value Query value
+local function parse_query_directive(line)
+  local key, value = line:match(PATTERN_QUERY)
+  if key and value then
+    return trim(key), trim(value)
+  end
+  return nil, nil
+end
+
+---Parse @restman.form directive
+---@param line string Line to parse (with prefix stripped)
+---@return string|nil key Form key
+---@return string|nil value Form value
+local function parse_form_directive(line)
+  local key, value = line:match(PATTERN_FORM)
+  if key and value then
+    return trim(key), trim(value)
+  end
+  return nil, nil
+end
+
+---Scan comment block above a request line for directives
+---Starts from line - 1, goes up, stops at blank line, non-comment, or MAX_SCAN_LINES
+---
+---@param bufnr number Buffer number
+---@param line number Line number (1-indexed) of the request line
+---@return Directives Parsed directives (may have nil fields)
+function M.scan_above(bufnr, line)
+  ---@type Directives
+  local result = {
+    body = nil,
+    headers = {},
+    query = {},
+    form = {},
+  }
+
+  -- Use current buffer (0) if not specified
+  if not bufnr then
+    bufnr = 0
+  end
+
+  -- No lines above to scan
+  if not line or line <= 1 then
+    return { body = nil, headers = nil, query = nil, form = nil }
+  end
+
+  -- Collect comment lines above request (going up from line - 1)
+  local comment_lines = {}
+  local current_line = line - 1
+
+  while current_line >= math.max(1, line - MAX_SCAN_LINES) do
+    local line_content = vim.api.nvim_buf_get_lines(bufnr, current_line - 1, current_line, false)[1]
+
+    if not line_content then
+      break
+    end
+
+    -- Stop at blank line
+    if is_blank(line_content) then
+      break
+    end
+
+    -- Try to strip comment prefix
+    local stripped = strip_comment_prefix(line_content)
+
+    -- Stop if not a comment line
+    if not stripped then
+      break
+    end
+
+    -- Add to front of array (to maintain order from top to bottom)
+    table.insert(comment_lines, 1, stripped)
+    current_line = current_line - 1
+  end
+
+  -- Parse directives from collected comment lines
+  local idx = 1
+  while idx <= #comment_lines do
+    local comment_line = comment_lines[idx]
+
+    -- Skip blank lines in comment block
+    if is_blank(comment_line) then
+      idx = idx + 1
+      goto continue
+    end
+
+    -- Check for @restman.body directive
+    if comment_line:match("^@restman%.body") then
+      result.body, idx = parse_body_directive(comment_lines, idx)
+      goto continue
+    end
+
+    -- Check for @restman.header directive
+    if comment_line:match("^@restman%.header") then
+      local key, value = parse_header_directive(comment_line)
+      if key and value then
+        result.headers[key] = value
+      end
+      idx = idx + 1
+      goto continue
+    end
+
+    -- Check for @restman.query directive
+    if comment_line:match("^@restman%.query") then
+      local key, value = parse_query_directive(comment_line)
+      if key and value then
+        result.query[key] = value
+      end
+      idx = idx + 1
+      goto continue
+    end
+
+    -- Check for @restman.form directive
+    if comment_line:match("^@restman%.form") then
+      local key, value = parse_form_directive(comment_line)
+      if key and value then
+        result.form[key] = value
+      end
+      idx = idx + 1
+      goto continue
+    end
+
+    -- Unknown directive or non-directive comment line - skip
+    idx = idx + 1
+
+    ::continue::
+  end
+
+  -- Clean up empty tables (convert to nil)
+  if not next(result.headers) then
+    result.headers = nil
+  end
+  if not next(result.query) then
+    result.query = nil
+  end
+  if not next(result.form) then
+    result.form = nil
+  end
+
+  return result
+end
+
+return M

--- a/lua/restman/parser/directives_test.lua
+++ b/lua/restman/parser/directives_test.lua
@@ -1,0 +1,294 @@
+-- Manual test for restman parser directives
+-- Run with: :luafile lua/restman/parser/directives_test.lua
+
+local project_root = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":h:h:h:h")
+package.path = project_root .. "/lua/?.lua;" .. package.path
+
+local directives = require("restman.parser.directives")
+
+-- Test helper functions
+local function test_case(description, test_fn)
+  local success, err = pcall(test_fn)
+  if success then
+    print("✅ " .. description)
+  else
+    print("❌ " .. description .. ": " .. tostring(err))
+  end
+end
+
+local function assert_eq(actual, expected, context)
+  if actual ~= expected then
+    error(string.format("%s: expected '%s' but got '%s'", context or "assertion failed", expected, actual))
+  end
+end
+
+local function assert_not_nil(value, context)
+  if value == nil then
+    error(string.format("%s: value is nil", context or "assertion failed"))
+  end
+end
+
+local function assert_deep_eq(actual, expected, context)
+  if type(actual) ~= type(expected) then
+    error(
+      string.format("%s: type mismatch - expected %s but got %s", context or "assertion failed", type(expected), type(actual))
+    )
+  end
+
+  if type(actual) == "table" then
+    for k, v in pairs(expected) do
+      assert_deep_eq(actual[k], v, context .. "." .. tostring(k))
+    end
+  else
+    if actual ~= expected then
+      error(string.format("%s: expected '%s' but got '%s'", context or "assertion failed", expected, actual))
+    end
+  end
+end
+
+-- Create a mock buffer for testing
+local function create_buffer(lines)
+  local bufnr = vim.api.nvim_create_buf(true, true)
+  vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  return bufnr
+end
+
+-- ========== TEST CASES ==========
+
+print("\n=== Directives Parser Tests ===\n")
+
+-- Test 1: Single-line body directive
+test_case("Single-line @restman.body with JSON", function()
+  local lines = {
+    '-- @restman.body { "name": "Alice" }',
+    "POST http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 2)
+
+  assert_not_nil(result.body, "body should not be nil")
+  assert_eq(type(result.body), "table", "body should be a table (parsed JSON)")
+  assert_eq(result.body.name, "Alice", "body.name should be 'Alice'")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 2: Multi-line body directive (scenario #5)
+test_case("Multi-line @restman.body (scenario #5)", function()
+  local lines = {
+    '-- @restman.body {',
+    '--   "title": "New article",',
+    '--   "tags": ["lua", "neovim"]',
+    '-- }',
+    "-- @restman.header Idempotency-Key: 7f3a",
+    "POST /api/{{API_VERSION}}/articles",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 6)
+
+  assert_not_nil(result.body, "body should not be nil")
+  assert_eq(type(result.body), "table", "body should be a table (parsed JSON)")
+  assert_eq(result.body.title, "New article", "body.title should be 'New article'")
+  assert_eq(type(result.body.tags), "table", "body.tags should be a table")
+  assert_eq(#result.body.tags, 2, "body.tags should have 2 items")
+  assert_eq(result.body.tags[1], "lua", "body.tags[1] should be 'lua'")
+  assert_eq(result.body.tags[2], "neovim", "body.tags[2] should be 'neovim'")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 3: Header directive
+test_case("@restman.header directive", function()
+  local lines = {
+    "-- @restman.header X-Trace-Id: abc-123",
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 2)
+
+  assert_not_nil(result.headers, "headers should not be nil")
+  assert_eq(result.headers["X-Trace-Id"], "abc-123", "X-Trace-Id header should be 'abc-123'")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 4: Multiple header directives
+test_case("Multiple @restman.header directives", function()
+  local lines = {
+    "-- @restman.header X-Trace-Id: abc-123",
+    "-- @restman.header Authorization: Bearer token",
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 3)
+
+  assert_not_nil(result.headers, "headers should not be nil")
+  assert_eq(result.headers["X-Trace-Id"], "abc-123", "X-Trace-Id header")
+  assert_eq(result.headers["Authorization"], "Bearer token", "Authorization header")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 5: Query directive
+test_case("@restman.query directive", function()
+  local lines = {
+    "-- @restman.query page=2",
+    "-- @restman.query size=10",
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 3)
+
+  assert_not_nil(result.query, "query should not be nil")
+  assert_eq(result.query.page, "2", "query.page should be '2'")
+  assert_eq(result.query.size, "10", "query.size should be '10'")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 6: Form directive
+test_case("@restman.form directive", function()
+  local lines = {
+    "-- @restman.form name=Alice",
+    "-- @restman.form email=alice@example.com",
+    "POST http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 3)
+
+  assert_not_nil(result.form, "form should not be nil")
+  assert_eq(result.form.name, "Alice", "form.name should be 'Alice'")
+  assert_eq(result.form.email, "alice@example.com", "form.email should be 'alice@example.com'")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 7: Different comment prefix styles
+test_case("Different comment prefix styles (#, //, --)", function()
+  -- Test with # prefix
+  local lines1 = {
+    "# @restman.body {\"test\": true}",
+    "GET http://localhost:3000/test",
+  }
+  local bufnr1 = create_buffer(lines1)
+  local result1 = directives.scan_above(bufnr1, 2)
+  assert_not_nil(result1.body, "body with # prefix")
+  vim.api.nvim_buf_delete(bufnr1, { force = true })
+
+  -- Test with // prefix
+  local lines2 = {
+    '// @restman.body {"test": true}',
+    "GET http://localhost:3000/test",
+  }
+  local bufnr2 = create_buffer(lines2)
+  local result2 = directives.scan_above(bufnr2, 2)
+  assert_not_nil(result2.body, "body with // prefix")
+  vim.api.nvim_buf_delete(bufnr2, { force = true })
+end)
+
+-- Test 8: Stop at blank line
+test_case("Stop scanning at blank line", function()
+  local lines = {
+    "-- @restman.header X-Old: ignored",
+    "",
+    "-- @restman.header X-Valid: abc",
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 4)
+
+  assert_not_nil(result.headers, "headers should not be nil")
+  assert_not_nil(result.headers["X-Valid"], "X-Valid header should exist")
+  assert_eq(result.headers["X-Valid"], "abc", "X-Valid header value")
+  assert_eq(result.headers["X-Old"], nil, "X-Old header should not exist (blank line stopped scan)")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 9: Stop at non-comment line
+test_case("Stop scanning at non-comment line", function()
+  local lines = {
+    "-- @restman.header X-Old: ignored",
+    "some code here",
+    "-- @restman.header X-Valid: abc",
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 4)
+
+  assert_not_nil(result.headers, "headers should not be nil")
+  assert_not_nil(result.headers["X-Valid"], "X-Valid header should exist")
+  assert_eq(result.headers["X-Old"], nil, "X-Old header should not exist (code line stopped scan)")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 10: Non-namespaced directives are ignored
+test_case("Non-namespaced directives are ignored", function()
+  local lines = {
+    "-- @body {\"should\": \"be ignored\"}",
+    "-- @header X-Test: ignored",
+    "-- @restman.header X-Valid: abc",
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 4)
+
+  assert_not_nil(result.headers, "headers should not be nil")
+  assert_eq(result.headers["X-Valid"], "abc", "X-Valid header should exist")
+  assert_eq(result.body, nil, "body should be nil (@body ignored)")
+  assert_eq(result.headers["X-Test"], nil, "X-Test header should not exist (@header ignored)")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 11: Invalid JSON body returns raw string
+test_case("Invalid JSON body returns raw string", function()
+  local lines = {
+    '-- @restman.body not valid json but plain text',
+    "POST http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 2)
+
+  assert_not_nil(result.body, "body should not be nil")
+  assert_eq(type(result.body), "string", "body should be a string (raw)")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 12: Empty result when no directives
+test_case("Empty result when no directives above", function()
+  local lines = {
+    "GET http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 1)
+
+  assert_eq(result.body, nil, "body should be nil")
+  assert_eq(result.headers, nil, "headers should be nil")
+  assert_eq(result.query, nil, "query should be nil")
+  assert_eq(result.form, nil, "form should be nil")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+-- Test 13: Combined directives (scenario #4)
+test_case("Combined directives (scenario #4)", function()
+  local lines = {
+    '-- @restman.body { "name": "OldValue" }',
+    '-- @restman.header X-Trace-Id: abc-123',
+    "POST http://localhost:3000/users",
+  }
+  local bufnr = create_buffer(lines)
+  local result = directives.scan_above(bufnr, 3)
+
+  assert_not_nil(result.body, "body should not be nil")
+  assert_eq(result.body.name, "OldValue", "body.name should be 'OldValue'")
+  assert_not_nil(result.headers, "headers should not be nil")
+  assert_eq(result.headers["X-Trace-Id"], "abc-123", "X-Trace-Id header")
+
+  vim.api.nvim_buf_delete(bufnr, { force = true })
+end)
+
+print("\n=== All tests completed ===\n")


### PR DESCRIPTION
## Summary

Implement `scan_above(bufnr, line)` parser function to extract `@restman.*` comment directives from lines above HTTP requests.

## What Changed

- **`lua/restman/parser/directives.lua`** — Main parser module (309 lines)
  - `scan_above(bufnr, line)` — scans comment block upward, extracts directives
  - Directive types: `@restman.body`, `@restman.header`, `@restman.query`, `@restman.form`
  - Multi-line body support with progressive JSON parsing
  - Comment prefix detection: `//`, `#`, `--`, `/*`, `*`

- **`lua/restman/parser/directives_test.lua`** — Comprehensive unit tests (295 lines)
  - 13 test cases covering all directives
  - Edge cases: blank lines, non-comment lines, invalid JSON, combined directives

## Test Plan

- [x] Single-line body: `-- @restman.body { "name": "Alice" }`
- [x] Multi-line body (scenario #5 from v1-usage.md)
- [x] Headers: `-- @restman.header X-Trace-Id: abc-123`
- [x] Query params: `-- @restman.query page=2`
- [x] Form params: `-- @restman.form name=Alice`
- [x] Different comment styles: `//`, `#`, `--`
- [x] Stop at blank line
- [x] Stop at non-comment line
- [x] Non-namespaced directives ignored
- [x] Invalid JSON returns raw string
- [x] No directives returns empty result

All 13 tests pass ✅

## Specification

Implements specs/issues/005-parser-directives.md per DoD in specs/story.md §2.3

🤖 Generated with [Claude Code](https://claude.com/claude-code)