### PR TITLE
feat: implement issues #10 (fix), #11, #12, #13 — UI wiring + command…

### DIFF
--- a/.luarc.json
+++ b/.luarc.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json",
+  "Lua.diagnostics.globals": ["vim"],
+  "Lua.workspace.library": {
+    "${3rd}/vim/library": true
+  },
+  "Lua.runtime.version": "LuaJIT"
+}

--- a/lua/restman/commands.lua
+++ b/lua/restman/commands.lua
@@ -1,0 +1,217 @@
+-- Commands & keymaps — :Restman dispatcher and subcommand handlers
+
+local M = {}
+local log = require("restman.log")
+
+-- Module state: last request sent
+M._last = nil
+
+---Register the :Restman user command
+function M.register()
+  vim.api.nvim_create_user_command("Restman", M._dispatch, {
+    nargs = "*",
+    range = true,
+    complete = M._complete,
+    desc = "Restman REST client",
+  })
+end
+
+---Main command dispatcher
+---@param opts table Command options from nvim_create_user_command
+local function _dispatch(opts)
+  local sub = opts.fargs[1]
+
+  if sub == "send" then
+    M._send(opts)
+  elseif sub == "repeat" then
+    M._repeat()
+  elseif sub == "env" then
+    M._env()
+  elseif sub == "history" then
+    M._history()
+  elseif sub == "cancel" then
+    M._cancel()
+  elseif sub == "rails" then
+    M._rails(opts)
+  elseif sub == "health" then
+    vim.cmd("checkhealth restman")
+  else
+    if sub then
+      log.warn("Restman: unknown subcommand '" .. tostring(sub) .. "'")
+    else
+      log.info("Restman: available subcommands: send, repeat, env, history, cancel, rails, health")
+    end
+  end
+end
+
+---Send request subcommand
+---@param opts table Command options with range support
+function M._send(opts)
+  local http_client = require("restman.http_client")
+  local buffer = require("restman.ui.buffer")
+  local view = require("restman.ui.view")
+  local parser = require("restman.parser")
+  local env = require("restman.env")
+  local config = require("restman.config")
+
+  local function do_send()
+    local bufnr = 0  -- Current buffer
+    local line = vim.api.nvim_win_get_cursor(0)[1]
+    local visual_block = nil
+
+    -- Range support: collect visual block as body
+    if opts.range > 0 then
+      local vlines = vim.api.nvim_buf_get_lines(bufnr, opts.line1 - 1, opts.line2, false)
+      visual_block = table.concat(vlines, "\n")
+      line = opts.line1
+    end
+
+    -- Parse request
+    parser.parse_current_line(bufnr, line, { visual_block = visual_block }, function(request)
+      if not request then
+        log.warn("Restman: no request found at cursor")
+        return
+      end
+
+      -- Apply environment
+      request = env.apply_to(request)
+      M._last = { request = request }
+
+      -- Send request
+      http_client.send(request, function(response)
+        -- Schedule on main thread
+        vim.schedule(function()
+          local resp_bufnr = buffer.create(request, response)
+          local cfg = config.get()
+          view.open(resp_bufnr, cfg.response_view.default_view)
+        end)
+      end)
+    end)
+  end
+
+  -- Check for pending request
+  if http_client.is_pending() then
+    vim.ui.input({ prompt = "Cancel previous request? [y/N] " }, function(input)
+      if input and input:lower() == "y" then
+        http_client.cancel()
+        do_send()
+      end
+    end)
+    return
+  end
+
+  do_send()
+end
+
+---Repeat last request subcommand
+function M._repeat()
+  if not M._last then
+    log.warn("Restman: no previous request to repeat")
+    return
+  end
+
+  local http_client = require("restman.http_client")
+  local buffer = require("restman.ui.buffer")
+  local view = require("restman.ui.view")
+  local config = require("restman.config")
+
+  http_client.send(M._last.request, function(response)
+    vim.schedule(function()
+      local resp_bufnr = buffer.create(M._last.request, response)
+      local cfg = config.get()
+      view.open(resp_bufnr, cfg.response_view.default_view)
+    end)
+  end)
+end
+
+---Select environment subcommand
+function M._env()
+  local picker = require("restman.ui.picker")
+  local env = require("restman.env")
+
+  picker.pick({
+    items = env.list(),
+    title = "Select Environment",
+    format = function(name)
+      return name
+    end,
+    on_select = function(name)
+      if not env.set_active(name) then
+        log.warn("Restman: environment '" .. name .. "' not found")
+      else
+        log.info("Restman: switched to environment '" .. name .. "'")
+      end
+    end,
+  })
+end
+
+---History subcommand (stub for issue #14)
+function M._history()
+  log.info("Restman: history not implemented yet, see issue #14")
+end
+
+---Cancel request subcommand
+function M._cancel()
+  local http_client = require("restman.http_client")
+  if http_client.is_pending() then
+    http_client.cancel()
+    log.info("Restman: request cancelled")
+  else
+    log.info("Restman: no request in flight")
+  end
+end
+
+---Rails subcommand (stub for issue #15)
+---@param opts table Command options
+function M._rails(opts)
+  local sub_sub = opts.fargs[2]
+  if sub_sub == "refresh" then
+    log.info("Restman: rails refresh not implemented yet, see issue #15")
+  else
+    log.info("Restman: rails not implemented yet, see issue #15")
+  end
+end
+
+---Tab completion for :Restman command
+---@param arg string Current argument being completed
+---@param line string Full command line
+---@param pos number Cursor position in line
+---@return string[] List of completions
+function M._complete(_arg, line, _pos)
+  local args = vim.split(line, "%s+")
+
+  -- Subcommand completion
+  if #args <= 2 then
+    return { "send", "repeat", "env", "history", "cancel", "rails", "health" }
+  end
+
+  -- Sub-subcommand completion (e.g., rails refresh)
+  if args[2] == "rails" then
+    return { "refresh" }
+  end
+
+  return {}
+end
+
+---Register default keymaps
+---@param cfg RestmanConfig Configuration table
+function M.register_keymaps(cfg)
+  local km = cfg.keymaps
+  local opts = { silent = true, noremap = true }
+
+  vim.keymap.set({ "n", "v" }, km.send, "<cmd>Restman send<CR>",
+    vim.tbl_extend("force", opts, { desc = "Restman: send request" }))
+  vim.keymap.set("n", km.repeat_last, "<cmd>Restman repeat<CR>",
+    vim.tbl_extend("force", opts, { desc = "Restman: repeat last" }))
+  vim.keymap.set("n", km.env, "<cmd>Restman env<CR>",
+    vim.tbl_extend("force", opts, { desc = "Restman: select env" }))
+  vim.keymap.set("n", km.history, "<cmd>Restman history<CR>",
+    vim.tbl_extend("force", opts, { desc = "Restman: history" }))
+  vim.keymap.set("n", km.cancel, "<cmd>Restman cancel<CR>",
+    vim.tbl_extend("force", opts, { desc = "Restman: cancel" }))
+end
+
+-- Expose dispatcher for command registration
+M._dispatch = _dispatch
+
+return M

--- a/lua/restman/init.lua
+++ b/lua/restman/init.lua
@@ -33,6 +33,12 @@ function M.setup(user_config)
   end
 
   M.config = config.merge(user_config)
+
+  -- Register commands and keymaps
+  local commands = require("restman.commands")
+  commands.register()
+  commands.register_keymaps(M.config)
+
   log.info("restman.nvim loaded successfully")
 
   return true

--- a/lua/restman/ui/picker.lua
+++ b/lua/restman/ui/picker.lua
@@ -1,0 +1,107 @@
+-- UI Picker layer — abstraction for Telescope + vim.ui.select fallback
+
+local M = {}
+local log = require("restman.log")
+
+-- Cache telescope availability (nil=unchecked, true/false after first check)
+M._has_telescope = nil
+M._current_mode = "float"
+
+---Check if Telescope is available (cached)
+---@return boolean True if telescope.pickers is available
+local function check_telescope()
+  if M._has_telescope == nil then
+    local ok = pcall(require, "telescope.pickers")
+    M._has_telescope = ok
+  end
+  return M._has_telescope
+end
+
+---Pick an item from a list (Telescope if available, vim.ui.select as fallback)
+---@param opts table Options: { items, format, on_select, on_secondary?, title }
+function M.pick(opts)
+  opts = opts or {}
+
+  if check_telescope() then
+    -- Telescope path
+    local pickers = require("telescope.pickers")
+    local finders = require("telescope.finders")
+    local conf = require("telescope.config").values
+    local actions = require("telescope.actions")
+    local action_state = require("telescope.actions.state")
+
+    pickers
+      .new({}, {
+        prompt_title = opts.title or "Select",
+        finder = finders.new_table({
+          results = opts.items,
+          entry_maker = function(item)
+            return {
+              value = item,
+              display = opts.format and opts.format(item) or tostring(item),
+              ordinal = opts.format and opts.format(item) or tostring(item),
+            }
+          end,
+        }),
+        sorter = conf.generic_sorter({}),
+        attach_mappings = function(prompt_bufnr, map)
+          actions.select_default:replace(function()
+            actions.close(prompt_bufnr)
+            local sel = action_state.get_selected_entry()
+            if sel and opts.on_select then
+              opts.on_select(sel.value)
+            end
+          end)
+          map("i", "<C-o>", function()
+            actions.close(prompt_bufnr)
+            local sel = action_state.get_selected_entry()
+            if sel and opts.on_secondary then
+              opts.on_secondary(sel.value)
+            end
+          end)
+          return true
+        end,
+      })
+      :find()
+  else
+    -- Fallback: vim.ui.select
+    if opts.on_secondary then
+      log.info("picker: upgrade to Telescope for <C-o> secondary action support")
+    end
+    vim.ui.select(opts.items, {
+      prompt = opts.title,
+      format_item = opts.format or tostring,
+    }, function(choice)
+      if choice and opts.on_select then
+        opts.on_select(choice)
+      end
+    end)
+  end
+end
+
+---Open picker for response buffer list
+function M.open_buffer_list()
+  local buffer = require("restman.ui.buffer")
+  local entries = buffer.list()
+
+  if #entries == 0 then
+    log.info("picker: no response buffers in history")
+    return
+  end
+
+  M.pick({
+    items = entries,
+    title = "Response Buffers",
+    format = function(entry)
+      local req = entry.request
+      return string.format("[%d] %s %s", entry.index, req.method or "?", req.url or "?")
+    end,
+    on_select = function(entry)
+      local view = require("restman.ui.view")
+      local mode = (view._current and view._current.mode) or M._current_mode
+      view.open(entry.bufnr, mode)
+    end,
+  })
+end
+
+return M

--- a/lua/restman/ui/render.lua
+++ b/lua/restman/ui/render.lua
@@ -5,6 +5,83 @@ local M = {}
 -- Create namespace for highlights
 local RESTMAN_NS = vim.api.nvim_create_namespace("restman")
 
+-- HTTP status text mapping
+local HTTP_STATUS_TEXT = {
+  [200] = "OK",
+  [201] = "Created",
+  [204] = "No Content",
+  [301] = "Moved Permanently",
+  [302] = "Found",
+  [304] = "Not Modified",
+  [400] = "Bad Request",
+  [401] = "Unauthorized",
+  [403] = "Forbidden",
+  [404] = "Not Found",
+  [405] = "Method Not Allowed",
+  [409] = "Conflict",
+  [422] = "Unprocessable Entity",
+  [429] = "Too Many Requests",
+  [500] = "Internal Server Error",
+  [502] = "Bad Gateway",
+  [503] = "Service Unavailable",
+}
+
+---Recursively serialize Lua table to JSON with 2-space indentation
+---@param val any Value to serialize
+---@param indent number Current indentation level (default 0)
+---@return string JSON string
+local function json_pretty(val, indent)
+  indent = indent or 0
+  local pad = string.rep("  ", indent)
+  local inner_pad = string.rep("  ", indent + 1)
+  local t = type(val)
+
+  if val == nil or val == vim.NIL then
+    return "null"
+  elseif t == "boolean" then
+    return tostring(val)
+  elseif t == "number" then
+    -- Format integers without decimal point
+    if val == math.floor(val) and math.abs(val) < 2 ^ 53 then
+      return string.format("%d", val)
+    end
+    return tostring(val)
+  elseif t == "string" then
+    -- Use vim.json.encode for safe string escaping (includes quotes)
+    return vim.json.encode(val)
+  elseif t == "table" then
+    -- Detect array vs object
+    local is_array = #val > 0
+    if is_array then
+      local items = {}
+      for _, v in ipairs(val) do
+        table.insert(items, inner_pad .. json_pretty(v, indent + 1))
+      end
+      if #items == 0 then
+        return "[]"
+      end
+      return "[\n" .. table.concat(items, ",\n") .. "\n" .. pad .. "]"
+    else
+      local entries = {}
+      -- Sort keys for deterministic output
+      local keys = vim.tbl_keys(val)
+      table.sort(keys, function(a, b)
+        return tostring(a) < tostring(b)
+      end)
+      for _, k in ipairs(keys) do
+        local key_str = vim.json.encode(tostring(k))
+        table.insert(entries, inner_pad .. key_str .. ": " .. json_pretty(val[k], indent + 1))
+      end
+      if #entries == 0 then
+        return "{}"
+      end
+      return "{\n" .. table.concat(entries, ",\n") .. "\n" .. pad .. "}"
+    end
+  end
+
+  return "null"
+end
+
 ---Format byte size to human-readable string
 ---@param bytes number Number of bytes
 ---@return string Formatted size (e.g., "1.2 KB", "256 B")
@@ -22,7 +99,7 @@ end
 ---@param code number HTTP status code
 ---@return table { text: string, hl_group: string }
 function M.format_status(code)
-  local text = code .. " " .. (require("restman.http_client").get_status_text and require("restman.http_client").get_status_text(code) or "Unknown")
+  local text = code .. " " .. (HTTP_STATUS_TEXT[code] or "Unknown")
 
   local hl_group = "Normal"
   if code >= 200 and code < 300 then
@@ -39,7 +116,7 @@ end
 ---Prettify body based on content type and detect filetype
 ---@param body string Raw response body
 ---@param content_type string|nil Content-Type header value
----@return string, string Prettified body, filetype for buffer
+---@return string, string|nil Prettified body, filetype for buffer
 function M.prettify(body, content_type)
   if not body or body == "" then
     return body, nil
@@ -52,7 +129,7 @@ function M.prettify(body, content_type)
     local success, decoded = pcall(vim.json.decode, body)
     if success then
       -- Pretty print with 2-space indent
-      local pretty = vim.inspect(decoded, { indent = 2 })
+      local pretty = json_pretty(decoded)
       return pretty, "json"
     end
   end

--- a/lua/restman/ui/view.lua
+++ b/lua/restman/ui/view.lua
@@ -1,0 +1,205 @@
+-- UI View layer — window management for response buffers (float/split/vsplit/tab + promote + keymaps)
+
+local M = {}
+local log = require("restman.log")
+
+-- Module state: current view { bufnr, winid, mode }
+M._current = nil
+
+---Setup buffer-local keymaps for response view
+---@param bufnr number Buffer number
+local function _setup_keymaps(bufnr)
+  -- Guard: only set keymaps once per buffer
+  if vim.b[bufnr].restman_keymaps_set then
+    return
+  end
+  vim.b[bufnr].restman_keymaps_set = true
+
+  local render = require("restman.ui.render")
+  local buffer = require("restman.ui.buffer")
+
+  local opts = { buffer = bufnr, nowait = true, silent = true }
+
+  -- Close view: q or Esc
+  vim.keymap.set("n", "q", function()
+    M.close()
+  end, opts)
+  vim.keymap.set("n", "<Esc>", function()
+    M.close()
+  end, opts)
+
+  -- Toggle headers: H
+  vim.keymap.set("n", "H", function()
+    local entry = buffer.get(bufnr)
+    if not entry then
+      return
+    end
+    local current_mode = vim.b[bufnr].restman_view_mode or "body"
+    local new_mode = (current_mode == "headers") and "body" or "headers"
+    render.render(bufnr, entry.request, entry.response, { mode = new_mode })
+  end, opts)
+
+  -- Show body: B
+  vim.keymap.set("n", "B", function()
+    local entry = buffer.get(bufnr)
+    if not entry then
+      return
+    end
+    render.render(bufnr, entry.request, entry.response, { mode = "body" })
+  end, opts)
+
+  -- Toggle raw: R
+  vim.keymap.set("n", "R", function()
+    local entry = buffer.get(bufnr)
+    if not entry then
+      return
+    end
+    local current_mode = vim.b[bufnr].restman_view_mode or "body"
+    local new_mode = (current_mode == "raw") and "body" or "raw"
+    render.render(bufnr, entry.request, entry.response, { mode = new_mode })
+  end, opts)
+
+  -- Yank body: y
+  vim.keymap.set("n", "y", function()
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 5, -1, false)
+    vim.fn.setreg("+", table.concat(lines, "\n"))
+    log.info("Body yanked to clipboard")
+  end, opts)
+
+  -- Yank full: yy
+  vim.keymap.set("n", "yy", function()
+    local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+    vim.fn.setreg("+", table.concat(lines, "\n"))
+    log.info("Full response yanked to clipboard")
+  end, opts)
+
+  -- Save to file: Enter
+  vim.keymap.set("n", "<CR>", function()
+    vim.ui.input({ prompt = "Save to file: " }, function(path)
+      if path and path ~= "" then
+        local lines = vim.api.nvim_buf_get_lines(bufnr, 5, -1, false)
+        local expanded_path = vim.fn.expand(path)
+        vim.fn.writefile(lines, expanded_path)
+        log.info("Saved to " .. expanded_path)
+      end
+    end)
+  end, opts)
+
+  -- Promote to split: s
+  vim.keymap.set("n", "s", function()
+    M.promote("split")
+  end, opts)
+
+  -- Promote to vsplit: v
+  vim.keymap.set("n", "v", function()
+    M.promote("vsplit")
+  end, opts)
+
+  -- Promote to tab: t
+  vim.keymap.set("n", "t", function()
+    M.promote("tab")
+  end, opts)
+
+  -- Open buffer list picker: C-o
+  vim.keymap.set("n", "<C-o>", function()
+    require("restman.ui.picker").open_buffer_list()
+  end, opts)
+end
+
+---Open a response buffer in a specific view mode
+---@param bufnr number Buffer number to display
+---@param mode string View mode: "float" | "split" | "vsplit" | "tab"
+function M.open(bufnr, mode)
+  -- Validate buffer
+  if not vim.api.nvim_buf_is_valid(bufnr) then
+    log.error("view.open: invalid buffer " .. bufnr)
+    return
+  end
+
+  -- Close existing view first
+  if M._current then
+    M.close()
+  end
+
+  local cfg = require("restman.config").get()
+
+  -- Open window based on mode
+  if mode == "float" then
+    -- Compute float dimensions from config
+    local flt_cfg = cfg.response_view.float
+    local w = math.floor(vim.o.columns * flt_cfg.width)
+    local h = math.floor(vim.o.lines * flt_cfg.height)
+    local row = math.floor((vim.o.lines - h) / 2)
+    local col = math.floor((vim.o.columns - w) / 2)
+
+    vim.api.nvim_open_win(bufnr, true, {
+      relative = flt_cfg.relative or "editor",
+      width = w,
+      height = h,
+      row = row,
+      col = col,
+      border = flt_cfg.border or "rounded",
+    })
+  elseif mode == "split" or mode == "vsplit" then
+    local split_cfg = cfg.response_view.split
+    local size = split_cfg.size or 80
+    vim.cmd("botright " .. size .. "vsplit")
+    vim.api.nvim_win_set_buf(0, bufnr)
+  elseif mode == "tab" then
+    vim.cmd("tabnew")
+    vim.api.nvim_win_set_buf(0, bufnr)
+  else
+    log.error("view.open: unknown mode " .. mode)
+    return
+  end
+
+  -- Save state
+  M._current = {
+    bufnr = bufnr,
+    winid = vim.api.nvim_get_current_win(),
+    mode = mode,
+  }
+
+  -- Setup keymaps (only once per buffer)
+  _setup_keymaps(bufnr)
+end
+
+---Close the current view (does not wipe buffer)
+function M.close()
+  if not M._current then
+    return
+  end
+
+  -- Close window safely
+  if vim.api.nvim_win_is_valid(M._current.winid) then
+    pcall(vim.api.nvim_win_close, M._current.winid, false)
+  end
+
+  M._current = nil
+end
+
+---Promote current view to a different mode (e.g., float → split)
+---@param new_mode string New view mode
+function M.promote(new_mode)
+  if not M._current then
+    log.warn("view.promote: no active view")
+    return
+  end
+
+  -- Capture current cursor position
+  local cursor = vim.api.nvim_win_get_cursor(M._current.winid)
+  local bufnr = M._current.bufnr
+
+  -- Close old view
+  M.close()
+
+  -- Open new view
+  M.open(bufnr, new_mode)
+
+  -- Restore cursor position
+  if vim.api.nvim_win_is_valid(M._current.winid) then
+    pcall(vim.api.nvim_win_set_cursor, M._current.winid, cursor)
+  end
+end
+
+return M

--- a/lua/telescope/_extensions/restman.lua
+++ b/lua/telescope/_extensions/restman.lua
@@ -1,0 +1,26 @@
+-- Telescope extension for Restman
+
+local telescope = require("telescope")
+local picker = require("restman.ui.picker")
+local env = require("restman.env")
+local log = require("restman.log")
+
+return telescope.register_extension({
+  exports = {
+    history = function()
+      -- Stub: history picker will be implemented in issue #14
+      log.info("history: not implemented yet, see issue #14")
+    end,
+    env = function()
+      -- Environment picker
+      picker.pick({
+        items = env.list(),
+        title = "Select Environment",
+        format = function(name)
+          return name
+        end,
+        on_select = env.set_active,
+      })
+    end,
+  },
+})

--- a/plugin/restman.lua
+++ b/plugin/restman.lua
@@ -5,12 +5,4 @@ if vim.fn.has("nvim-0.10") == 0 then
   return
 end
 
--- Lazy load the plugin
-vim.api.nvim_create_user_command("Restman", function(opts)
-  -- TODO: Implement subcommand dispatcher
-  -- For now, just show a message
-  vim.notify("[Restman] Plugin loaded. Subcommands not yet implemented.", vim.log.levels.INFO)
-end, {
-  nargs = "*",
-  desc = "Restman.nvim - REST client for Neovim",
-})
+-- Commands and keymaps are registered via require("restman").setup()


### PR DESCRIPTION
…s dispatcher

Issues #10-#13 complete the REST client UI and command layer:

**#10 fixes (render.lua):**
- Add HTTP_STATUS_TEXT mapping to fix "Unknown" status display
- Implement json_pretty() for valid JSON output (replaces vim.inspect)
- Fix M.prettify return type annotation

**#11 (view.lua):** Window management for response buffers
- M.open(bufnr, mode) — float/split/vsplit/tab modes
- M.close() — close window, preserve buffer
- M.promote(new_mode) — switch view modes with cursor preservation
- 12 buffer-local keymaps (q/Esc/H/B/R/y/yy/CR/s/v/t/C-o)
  - H/R toggle headers/raw modes
  - s/v/t promote to split/vsplit/tab
  - C-o opens buffer picker
  - y/yy copy body/full, CR saves to file

**#12 (picker.lua):** Picker abstraction
- M.pick() with Telescope if available, vim.ui.select fallback
- M.open_buffer_list() to switch between response buffers
- <C-o> action support in Telescope (secondary keybinding)
- lua/telescope/_extensions/restman.lua for :Telescope restman {history,env}

**#13 (commands.lua + wiring):** Main dispatcher
- :Restman send — parse line → env apply → http send → open response
  - Supports visual range as request body
  - Pending request guard with cancel prompt
- :Restman repeat — re-send last request (RAM-only state)
- :Restman env — environment picker
- :Restman history/cancel/rails — stubs for #14/#15
- :Restman health — checkhealth integration
- Tab completion for subcommands
- Default keymaps from config: <leader>rs/rr/re/rh/rc

**Other:**
- .luarc.json — silence "undefined-global vim" linter warnings
- init.lua — call commands.register() + register_keymaps() in setup()
- plugin/restman.lua — remove stub command (commands.lua owns it now)

All 23 existing tests pass. Ready for manual feature testing.