### PR TITLE
feat: implement Rails Grape mounted API integration with fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,4 @@
-# Restman.nvim — AI Context
-
-> Đọc file này đầu tiên mỗi session. Nó là entry point tham chiếu cho mọi quyết định.
+# Restman.nvim
 
 ## Project
 **Restman.nvim** — Neovim plugin đóng vai trò REST client với triết lý **one-key experience, frictionless**. Đặt con trỏ trên một dòng request → bấm 1 phím → nhận kết quả trong floating window.
@@ -26,5 +24,5 @@
 - **Telescope:** optional. Luôn `pcall(require, "telescope")` + fallback `vim.ui.select`.
 
 ### Mcp
-Github: https://github.com/nxhung2304/courier.nvim
+Github: https://github.com/nxhung2304/restman.nvim
 

--- a/lua/restman/commands.lua
+++ b/lua/restman/commands.lua
@@ -249,8 +249,25 @@ end
 ---Rails subcommand (stub for issue #15)
 ---@param opts table Command options
 function M._rails(opts)
+  local sub_sub = opts.fargs[2]
   local rails = require("restman.integrations.rails")
-  rails.open({ refresh = opts.fargs[2] == "refresh" })
+  local project_root = rails._find_project_root(rails._get_current_dir())
+
+  if sub_sub == "grape" then
+    M._rails_grape(opts)
+  else
+    if project_root and rails.detect_grape_mount(project_root) then
+      log.info("Restman: detected mounted Grape API; loading grape routes fallback")
+    end
+    rails.open({ refresh = sub_sub == "refresh" })
+  end
+end
+
+---Rails Grape subcommand
+---@param opts table Command options
+function M._rails_grape(opts)
+  local rails_grape = require("restman.integrations.rails_grape")
+  rails_grape.open({ refresh = opts.fargs[3] == "refresh" })
 end
 
 ---Tab completion for :Restman command
@@ -276,7 +293,11 @@ function M._complete(arg, line)
 
   -- Sub-subcommand completion (e.g., rails refresh, history clear)
   if args[2] == "rails" then
-    return filter({ "refresh" })
+    if #args <= 3 then
+      return filter({ "grape", "refresh" })
+    elseif args[3] == "grape" then
+      return filter({ "refresh" })
+    end
   end
   if args[2] == "history" then
     return filter({ "clear" })

--- a/lua/restman/config.lua
+++ b/lua/restman/config.lua
@@ -20,7 +20,11 @@ local M = {}
 
 ---@class RailsConfig
 ---@field cache_file? string Path to cache file (auto-generated if nil)
+---@field grape_cache_file? string Path to grape route cache file (auto-generated if nil)
 ---@field command string Command to list routes (default: "bin/rails routes")
+---@field grape_command string Command to list grape routes (default: "bundle exec rake grape:routes")
+---@field grape_description_format string Format for Grape route description in picker (default: " → %s")
+---                                      Use %s as placeholder for description text
 
 ---@type RestmanConfig
 M.defaults = {
@@ -59,7 +63,10 @@ M.defaults = {
 
   rails = {
     cache_file = nil, -- Will use default: vim.fn.stdpath("cache") .. "/restman/rails_routes.txt"
+    grape_cache_file = nil, -- Will use default: project_root .. "/.cache/restman/rails_grape_routes.txt"
     command = "bin/rails routes",
+    grape_command = "bundle exec rake grape:routes",
+    grape_description_format = " → %s", -- Format: %s = description text
   },
 }
 

--- a/lua/restman/integrations/rails.lua
+++ b/lua/restman/integrations/rails.lua
@@ -75,6 +75,8 @@ local function ensure_gitignore(project_root)
   vim.fn.writefile(lines, gitignore)
 end
 
+local detect_grape_mount
+
 local function compare_mtime(a, b)
   local a_sec = a.sec or 0
   local b_sec = b.sec or 0
@@ -169,14 +171,32 @@ local function cache_is_stale(routes_file, cache_file)
   return compare_mtime(routes_stat.mtime, cache_stat.mtime) > 0
 end
 
+local function format_route_for_picker(route, description_format)
+  description_format = description_format or " → %s"
+  local desc_part = ""
+
+  -- Check if action looks like a description (not controller#action format)
+  if route.action and route.action ~= "" and not route.action:find("#", 1, true) then
+    desc_part = string.format(description_format, route.action)
+  end
+
+  if desc_part ~= "" then
+    return string.format("%-6s %s%s", route.verb, route.path, desc_part)
+  else
+    return string.format("%-6s %s %s", route.verb, route.path, route.action)
+  end
+end
+
 local function open_picker(routes)
   local picker = require("restman.ui.picker")
+  local cfg = config.get()
+  local description_format = cfg.rails.grape_description_format or " → %s"
 
   picker.pick({
     items = routes,
     title = "Rails Routes",
     format = function(route)
-      return string.format("%-6s %s %s", route.verb, route.path, route.action)
+      return format_route_for_picker(route, description_format)
     end,
     on_select = function(route)
       M.send_route(route)
@@ -204,7 +224,80 @@ local function send_request(request)
   end)
 end
 
-local function load_from_command(project_root, cache_file, callback)
+local function merge_routes(base_routes, extra_routes)
+  local merged = {}
+  local seen = {}
+
+  for _, route in ipairs(base_routes or {}) do
+    -- Use only verb + path as key (ignore action to avoid duplicates)
+    local key = route.verb .. " " .. route.path
+    if not seen[key] then
+      seen[key] = true
+      table.insert(merged, route)
+    end
+  end
+
+  for _, route in ipairs(extra_routes or {}) do
+    -- Use only verb + path as key (ignore action to avoid duplicates)
+    local key = route.verb .. " " .. route.path
+    if not seen[key] then
+      seen[key] = true
+      table.insert(merged, route)
+    end
+  end
+
+  return merged
+end
+
+local function sort_routes_by_api(routes)
+  table.sort(routes, function(a, b)
+    -- Check if routes have /api in path
+    local a_has_api = a.path:find("/api", 1, true) ~= nil
+    local b_has_api = b.path:find("/api", 1, true) ~= nil
+
+    -- If one has /api and the other doesn't, /api comes first
+    if a_has_api ~= b_has_api then
+      return a_has_api
+    end
+
+    -- Otherwise, maintain original order by path
+    return a.path < b.path
+  end)
+  return routes
+end
+
+local function load_optional_grape_routes(project_root, base_routes, opts, callback)
+  if not detect_grape_mount(project_root) then
+    log.info("Restman: no Grape mount detected in config/routes.rb")
+    base_routes = sort_routes_by_api(base_routes or {})
+    log.info("Restman: " .. #(base_routes or {}) .. " Rails routes loaded")
+    callback(base_routes)
+    return
+  end
+
+  log.info("Restman: detected Grape mount, attempting to load Grape routes...")
+  local rails_grape = require("restman.integrations.rails_grape")
+  rails_grape.load_routes(opts, function(grape_routes)
+    if not grape_routes or #grape_routes == 0 then
+      log.warn("Detected mounted Grape API, but grape:routes could not be loaded; Rails routes may be incomplete")
+      base_routes = sort_routes_by_api(base_routes or {})
+      callback(base_routes)
+      return
+    end
+
+    log.info("Restman: loaded " .. #(grape_routes or {}) .. " Grape routes")
+    log.info("Restman: " .. #(base_routes or {}) .. " Rails routes")
+
+    -- Prioritize Grape routes (API) first, then add Rails routes (sorted by /api)
+    local sorted_base = sort_routes_by_api(base_routes or {})
+    local merged = merge_routes(grape_routes, sorted_base)
+
+    log.info("Restman: merged to " .. #merged .. " total routes")
+    callback(merged)
+  end)
+end
+
+local function load_from_command(project_root, cache_file, opts, callback)
   local cfg = config.get()
   local cmd = vim.split(cfg.rails.command or "bin/rails routes", "%s+", { trimempty = true })
 
@@ -217,13 +310,14 @@ local function load_from_command(project_root, cache_file, callback)
       if result.code ~= 0 then
         local stderr = vim.trim(result.stderr or "")
         log.error("rails routes failed" .. (stderr ~= "" and (": " .. stderr) or ""))
-        callback(nil)
+        load_optional_grape_routes(project_root, nil, opts, callback)
         return
       end
 
       local stdout = result.stdout or ""
       vim.fn.writefile(vim.split(stdout, "\n", { plain = true }), cache_file)
-      callback(parse_routes_output(stdout))
+      local routes = parse_routes_output(stdout)
+      load_optional_grape_routes(project_root, routes, opts, callback)
     end)
   end)
 end
@@ -279,11 +373,11 @@ function M.load_routes(opts, callback)
       log.warn("routes.rb has changed, run :Restman rails refresh")
     end
     M._last_cache_read_ns = vim.uv.hrtime() - started_at
-    callback(cached_routes)
+    load_optional_grape_routes(project_root, cached_routes, opts, callback)
     return
   end
 
-  load_from_command(project_root, cache_file, callback)
+  load_from_command(project_root, cache_file, opts, callback)
 end
 
 function M.open(opts)
@@ -295,10 +389,38 @@ function M.open(opts)
   end)
 end
 
+detect_grape_mount = function(project_root)
+  local routes_file = get_routes_file(project_root)
+  if vim.fn.filereadable(routes_file) == 0 then
+    return false
+  end
+
+  local content = table.concat(vim.fn.readfile(routes_file), "\n")
+
+  -- Look for common patterns like mount Api::Base => "/" or mount Api::Base => '/'
+  local patterns = {
+    "mount%s+[^%s]+::Base%s+=>%s+[\"'][^\"']+[\"']",
+    "mount%s+[^%s]+::V[0-9]+::Base%s+=>%s+[\"'][^\"']+[\"']",
+  }
+
+  for _, pattern in ipairs(patterns) do
+    if content:match(pattern) then
+      return true
+    end
+  end
+
+  return false
+end
+
 M._find_project_root = find_project_root
+M._get_current_dir = get_current_dir
 M._parse_route_line = parse_route_line
 M._parse_routes_output = parse_routes_output
 M._cache_is_stale = cache_is_stale
 M._get_cache_file = get_cache_file
+M._format_route_for_picker = format_route_for_picker
+M._merge_routes = merge_routes
+M._sort_routes_by_api = sort_routes_by_api
+M.detect_grape_mount = detect_grape_mount
 
 return M

--- a/lua/restman/integrations/rails_grape.lua
+++ b/lua/restman/integrations/rails_grape.lua
@@ -1,0 +1,282 @@
+local M = {}
+
+local config = require("restman.config")
+local log = require("restman.log")
+local picker = require("restman.ui.picker")
+local http_client = require("restman.http_client")
+local buffer = require("restman.ui.buffer")
+local view = require("restman.ui.view")
+local history = require("restman.history")
+local parser = require("restman.parser")
+local env = require("restman.env")
+local commands = require("restman.commands")
+
+-- Re-use functions from rails.lua or define new ones specific to Grape
+local rails_integration = require("restman.integrations.rails")
+
+local find_project_root = rails_integration._find_project_root
+local get_project_root = function()
+  return find_project_root(rails_integration._get_current_dir())
+end
+
+local function get_grape_cache_file(project_root)
+  local cfg = config.get()
+  return cfg.rails.grape_cache_file or (project_root .. "/.cache/restman/rails_grape_routes.txt")
+end
+
+local function ensure_cache_dir(cache_file)
+  vim.fn.mkdir(vim.fn.fnamemodify(cache_file, ":h"), "p")
+end
+
+local HTTP_METHODS = {
+  GET = true,
+  POST = true,
+  PUT = true,
+  PATCH = true,
+  DELETE = true,
+  HEAD = true,
+  OPTIONS = true,
+  CONNECT = true,
+  TRACE = true,
+}
+
+local function compare_mtime(a, b)
+  local a_sec = a.sec or 0
+  local b_sec = b.sec or 0
+  if a_sec ~= b_sec then
+    return a_sec - b_sec
+  end
+  return (a.nsec or 0) - (b.nsec or 0)
+end
+
+local function normalize_verb(value)
+  if not value then
+    return nil
+  end
+  local upper = tostring(value):upper()
+  return HTTP_METHODS[upper] and upper or nil
+end
+
+local function normalize_path(value)
+  local path = vim.trim(value or "")
+  if path == "" then
+    return path
+  end
+  path = path:gsub("%(%.:format%)", "")
+  path = path:gsub("%(%.format%)", "")
+  return path
+end
+
+local function parse_grape_route_line(line)
+  if not line or line == "" then
+    return nil
+  end
+
+  local trimmed = vim.trim(line)
+  if trimmed == "" or trimmed:match("^Prefix%s+Verb%s+") or trimmed:match("^HTTP%s+PATH") then
+    return nil
+  end
+
+  -- Handle both formats:
+  -- 1. Space-separated: GET /api/users(.:format) Api::Users#index
+  -- 2. Pipe-separated: GET  |  /oauth/token(.:format)  |  ...  |  Description
+
+  local verb, path, action
+
+  if line:find("|") then
+    -- Pipe-separated format from grape:routes
+    local parts = vim.split(line, "|", { trimempty = true })
+    if #parts < 2 then
+      return nil
+    end
+    verb = normalize_verb(vim.trim(parts[1]))
+    path = normalize_path(vim.trim(parts[2]))
+    -- Try to get description from parts[3] or parts[4]
+    action = vim.trim(parts[#parts] or "")
+    if action == "" then
+      action = "Grape API"
+    end
+  else
+    -- Space-separated format
+    local columns = vim.split(trimmed, "%s+", { trimempty = true })
+    if #columns < 2 then
+      return nil
+    end
+    verb = normalize_verb(columns[1])
+    path = normalize_path(columns[2] or "")
+    action = columns[#columns] or "Grape API"
+  end
+
+  if not verb or path == "" then
+    return nil
+  end
+
+  return {
+    verb = verb,
+    path = path,
+    action = action,
+  }
+end
+
+local function parse_grape_routes_output(content)
+  local routes = {}
+  for _, line in ipairs(vim.split(content or "", "\n", { trimempty = true })) do
+    local route = parse_grape_route_line(line)
+    if route then
+      table.insert(routes, route)
+    end
+  end
+  return routes
+end
+
+local function read_cached_grape_routes(cache_file)
+  if vim.fn.filereadable(cache_file) == 0 then
+    return nil
+  end
+  local lines = vim.fn.readfile(cache_file)
+  return parse_grape_routes_output(table.concat(lines, "\n"))
+end
+
+local function grape_cache_is_stale(project_root, cache_file)
+  local routes_file = project_root .. "/config/routes.rb"
+  local routes_stat = vim.uv.fs_stat(routes_file)
+  local cache_stat = vim.uv.fs_stat(cache_file)
+  if not routes_stat or not cache_stat or not routes_stat.mtime or not cache_stat.mtime then
+    return false
+  end
+  return compare_mtime(routes_stat.mtime, cache_stat.mtime) > 0
+end
+
+local function format_grape_route_for_picker(route, description_format)
+  description_format = description_format or " → %s"
+  local desc_part = ""
+  if route.action and route.action ~= "" and route.action ~= "Grape API" then
+    desc_part = string.format(description_format, route.action)
+  end
+  return string.format("%-6s %s%s", route.verb, route.path, desc_part)
+end
+
+local function open_picker(routes)
+  local cfg = config.get()
+  local description_format = cfg.rails.grape_description_format or " → %s"
+
+  picker.pick({
+    items = routes,
+    title = "Grape Routes",
+    format = function(route)
+      return format_grape_route_for_picker(route, description_format)
+    end,
+    on_select = function(route)
+      M.send_route(route)
+    end,
+  })
+end
+
+local function send_request(request)
+  commands._last = { request = request }
+
+  http_client.send(request, function(response)
+    vim.schedule(function()
+      local resp_bufnr = buffer.create(request, response)
+      local cfg = config.get()
+      view.open(resp_bufnr, cfg.response_view.default_view)
+      if response.status then
+        history.append(request, response, resp_bufnr)
+      end
+    end)
+  end)
+end
+
+local function load_from_command(project_root, cache_file, callback)
+  local cfg = config.get()
+  local cmd = vim.split(cfg.rails.grape_command or "bundle exec rake grape:routes", "%s+", { trimempty = true })
+
+  ensure_cache_dir(cache_file)
+  log.info("Loading Grape routes...")
+
+  vim.system(cmd, { cwd = project_root, text = true }, function(result)
+    vim.schedule(function()
+      if result.code ~= 0 then
+        local stderr = vim.trim(result.stderr or "")
+        log.error("grape:routes failed" .. (stderr ~= "" and (": " .. stderr) or ""))
+        callback(nil)
+        return
+      end
+
+      local stdout = result.stdout or ""
+      vim.fn.writefile(vim.split(stdout, "\n", { plain = true }), cache_file)
+      callback(parse_grape_routes_output(stdout))
+    end)
+  end)
+end
+
+function M.send_route(route)
+  local project_root = get_project_root()
+  local request = {
+    method = route.verb,
+    url = route.path,
+    headers = {},
+    source = {
+      file = "Grape API", -- Placeholder for source file
+      line = 1,
+    },
+  }
+
+  parser.resolve_dynamic_params(request.url, "Grape API", function(resolved_url) -- Placeholder for source file
+    request.url = resolved_url
+    env.apply_to_async(
+      request,
+      { project_root = project_root, force_detect = true },
+      function(resolved_request)
+        send_request(resolved_request)
+      end
+    )
+  end)
+end
+
+function M.load_routes(opts, callback)
+  opts = opts or {}
+  local project_root = get_project_root()
+  local routes_file = project_root .. "/config/routes.rb"
+
+  if vim.fn.filereadable(routes_file) == 0 then
+    log.error("Not a Rails project (config/routes.rb not found)")
+    callback(nil)
+    return
+  end
+
+  local cache_file = get_grape_cache_file(project_root)
+  if opts.refresh then
+    os.remove(cache_file)
+    env.clear_base_url_cache(project_root)
+  end
+
+  local started_at = vim.uv.hrtime()
+  local cached_routes = read_cached_grape_routes(cache_file)
+  if cached_routes then
+    if grape_cache_is_stale(project_root, cache_file) then
+      log.warn("Grape routes might be stale, run :Restman rails grape refresh")
+    end
+    M._last_cache_read_ns = vim.uv.hrtime() - started_at
+    callback(cached_routes)
+    return
+  end
+
+  load_from_command(project_root, cache_file, callback)
+end
+
+function M.open(opts)
+  M.load_routes(opts, function(routes)
+    if not routes or #routes == 0 then
+      return
+    end
+    open_picker(routes)
+  end)
+end
+
+M._get_grape_cache_file = get_grape_cache_file
+M._parse_grape_route_line = parse_grape_route_line
+M._parse_grape_routes_output = parse_grape_routes_output
+M._format_grape_route_for_picker = format_grape_route_for_picker
+
+return M

--- a/lua/restman/integrations/rails_grape_test.lua
+++ b/lua/restman/integrations/rails_grape_test.lua
@@ -1,0 +1,101 @@
+local project_root = vim.fn.fnamemodify(debug.getinfo(1).source:sub(2), ":h:h:h:h")
+package.path = project_root .. "/lua/?.lua;" .. package.path
+
+local rails_grape = require("restman.integrations.rails_grape")
+
+local function test_case(description, test_fn)
+  local success, err = pcall(test_fn)
+  if success then
+    print("✅ " .. description)
+  else
+    print("❌ " .. description .. ": " .. tostring(err))
+  end
+end
+
+local function assert_eq(actual, expected, context)
+  if actual ~= expected then
+    error(string.format("%s: expected '%s' but got '%s'", context or "assertion", expected, actual))
+  end
+end
+
+local function assert_truthy(value, context)
+  if not value then
+    error(string.format("%s: value is falsy", context or "assertion"))
+  end
+end
+
+print("\n=== Rails Grape Integration Tests ===\n")
+
+test_case("Parse Grape route line (pipe-separated format)", function()
+  local route = rails_grape._parse_grape_route_line("     POST  |  /oauth/token(.:format)                                     |    |  Requires for an access token")
+  assert_truthy(route, "route should parse")
+  assert_eq(route.verb, "POST", "verb")
+  assert_eq(route.path, "/oauth/token", "path")
+end)
+
+test_case("Parse Grape route line (space-separated format)", function()
+  local route = rails_grape._parse_grape_route_line("GET /api/users(.:format) Api::Users#index")
+  assert_truthy(route, "route should parse")
+  assert_eq(route.verb, "GET", "verb")
+  assert_eq(route.path, "/api/users", "path")
+end)
+
+test_case("Ignore Grape header row", function()
+  local route = rails_grape._parse_grape_route_line("Prefix Verb Path Action")
+  assert_eq(route, nil, "header should be ignored")
+end)
+
+test_case("Parse full Grape routes output (pipe-separated)", function()
+  local routes = rails_grape._parse_grape_routes_output(table.concat({
+    "     POST  |  /oauth/token(.:format)                                     |    |  Requires for an access token",
+    "      GET  |  /oauth/token/info(.:format)                                |    |  Information for an access token",
+    "      GET  |  /api/user(.:format)                                        |    |",
+  }, "\n"))
+  assert_eq(#routes, 3, "route count")
+  assert_eq(routes[1].verb, "POST", "first verb")
+  assert_eq(routes[2].verb, "GET", "second verb")
+  assert_eq(routes[3].path, "/api/user", "third path")
+end)
+
+test_case("Format Grape route with description", function()
+  local route = {
+    verb = "POST",
+    path = "/oauth/token",
+    action = "Requires for an access token"
+  }
+  local formatted = rails_grape._format_grape_route_for_picker(route, " → %s")
+  -- Should apply arrow format for Grape descriptions
+  assert_truthy(formatted:find("POST"), "verb should be in output")
+  assert_truthy(formatted:find("/oauth/token"), "path should be in output")
+  assert_truthy(formatted:find("→"), "arrow should be in formatted output")
+  assert_truthy(formatted:find("Requires for an access token"), "description should be in output")
+end)
+
+test_case("Format Grape route without description", function()
+  local route = {
+    verb = "GET",
+    path = "/api/user",
+    action = ""  -- No description
+  }
+  local formatted = rails_grape._format_grape_route_for_picker(route, " → %s")
+  -- Should NOT apply arrow format for empty descriptions
+  assert_truthy(formatted:find("GET"), "verb should be in output")
+  assert_truthy(formatted:find("/api/user"), "path should be in output")
+  assert_eq(formatted:find("→"), nil, "arrow should NOT be in output for empty description")
+end)
+
+test_case("Format Grape route with pipe description format", function()
+  local route = {
+    verb = "GET",
+    path = "/oauth/token/info",
+    action = "Information for an access token"
+  }
+  local formatted = rails_grape._format_grape_route_for_picker(route, " | %s")
+  -- Should use pipe format
+  assert_truthy(formatted:find("GET"), "verb should be in output")
+  assert_truthy(formatted:find("/oauth/token/info"), "path should be in output")
+  assert_truthy(formatted:find("|"), "pipe should be in formatted output")
+  assert_truthy(formatted:find("Information for an access token"), "description should be in output")
+end)
+
+print("\n=== Rails Grape Integration Tests Complete ===\n")

--- a/lua/restman/integrations/rails_test.lua
+++ b/lua/restman/integrations/rails_test.lua
@@ -59,6 +59,17 @@ test_case("Parse full routes output", function()
   assert_eq(routes[3].action, "users#destroy", "third action")
 end)
 
+test_case("Detect Grape mount in routes.rb", function()
+  local tmp = vim.fn.tempname()
+  vim.fn.mkdir(tmp, "p")
+  local config_dir = tmp .. "/config"
+  vim.fn.mkdir(config_dir, "p")
+  local routes_file = config_dir .. "/routes.rb"
+  vim.fn.writefile({"Rails.application.routes.draw do", "  mount Api::Base => '/'", "end"}, routes_file)
+
+  assert_truthy(rails.detect_grape_mount(tmp), "should detect mounted Grape API")
+end)
+
 test_case("Detect stale cache by mtime", function()
   local tmp = vim.fn.tempname()
   vim.fn.mkdir(tmp, "p")
@@ -73,6 +84,106 @@ test_case("Detect stale cache by mtime", function()
   vim.wait(20)
   vim.fn.writefile({ "Rails.application.routes.draw do", "resources :users", "end" }, routes_file)
   assert_eq(rails._cache_is_stale(routes_file, cache_file), true, "updated routes should be stale")
+end)
+
+test_case("Format function for Rails controller#action", function()
+  local route = {
+    verb = "GET",
+    path = "/users",
+    action = "users#index"
+  }
+  local formatted = rails._format_route_for_picker(route, " → %s")
+  -- Should keep original format for controller#action routes
+  assert_truthy(formatted:find("GET"), "verb should be in output")
+  assert_truthy(formatted:find("/users"), "path should be in output")
+  assert_truthy(formatted:find("users#index"), "action should be in output")
+  assert_eq(formatted:find("→"), nil, "arrow format should NOT be applied to controller#action")
+end)
+
+test_case("Format function for Grape description (arrow format)", function()
+  local route = {
+    verb = "POST",
+    path = "/oauth/token",
+    action = "Requires for an access token"  -- Description without "#"
+  }
+  local formatted = rails._format_route_for_picker(route, " → %s")
+  -- Should apply arrow format for descriptions
+  assert_truthy(formatted:find("POST"), "verb should be in output")
+  assert_truthy(formatted:find("/oauth/token"), "path should be in output")
+  assert_truthy(formatted:find("→"), "arrow should be in formatted output")
+  assert_truthy(formatted:find("Requires for an access token"), "description should be in output")
+end)
+
+test_case("Format function with custom description format", function()
+  local route = {
+    verb = "POST",
+    path = "/api/v1/auth",
+    action = "User authentication endpoint"  -- Description
+  }
+  local formatted = rails._format_route_for_picker(route, " | %s")
+  -- Should use pipe format instead of arrow
+  assert_truthy(formatted:find("POST"), "verb should be in output")
+  assert_truthy(formatted:find("/api/v1/auth"), "path should be in output")
+  assert_truthy(formatted:find("|"), "pipe should be in formatted output")
+  assert_truthy(formatted:find("User authentication endpoint"), "description should be in output")
+end)
+
+test_case("Format function with bracket description format", function()
+  local route = {
+    verb = "DELETE",
+    path = "/users/:id",
+    action = "Remove user account"
+  }
+  local formatted = rails._format_route_for_picker(route, " [%s]")
+  -- Should use bracket format
+  assert_truthy(formatted:find("DELETE"), "verb should be in output")
+  assert_truthy(formatted:find("/users/:id"), "path should be in output")
+  assert_truthy(formatted:find("%["), "opening bracket should be in output")
+  assert_truthy(formatted:find("%]"), "closing bracket should be in output")
+  assert_truthy(formatted:find("Remove user account"), "description should be in output")
+end)
+
+test_case("Merge routes removes duplicates correctly", function()
+  local base_routes = {
+    { verb = "GET", path = "/users", action = "users#index" },
+    { verb = "POST", path = "/users", action = "users#create" },
+    { verb = "PUT", path = "/api/user", action = "Grape description here" },  -- Duplicate with different action
+  }
+  local extra_routes = {
+    { verb = "PUT", path = "/api/user", action = "users#update" },  -- Duplicate (verb+path same)
+    { verb = "DELETE", path = "/users/:id", action = "users#destroy" },
+  }
+
+  local merged = rails._merge_routes(base_routes, extra_routes)
+  -- Should have 4 routes: GET /users, POST /users, PUT /api/user, DELETE /users/:id
+  assert_eq(#merged, 4, "merged should have 4 routes (1 duplicate removed)")
+
+  -- Verify correct routes are present
+  local verb_paths = {}
+  for _, route in ipairs(merged) do
+    table.insert(verb_paths, route.verb .. " " .. route.path)
+  end
+  assert_truthy(table.concat(verb_paths, ","):find("GET /users"), "GET /users should be present")
+  assert_truthy(table.concat(verb_paths, ","):find("POST /users"), "POST /users should be present")
+  assert_truthy(table.concat(verb_paths, ","):find("PUT /api/user"), "PUT /api/user should be present")
+  assert_truthy(table.concat(verb_paths, ","):find("DELETE /users/:id"), "DELETE /users/:id should be present")
+end)
+
+test_case("Sort routes prioritizes /api paths", function()
+  local routes = {
+    { verb = "GET", path = "/users", action = "users#index" },
+    { verb = "GET", path = "/api/v1/users", action = "api_users#index" },
+    { verb = "GET", path = "/admin/users", action = "admin_users#index" },
+    { verb = "GET", path = "/api/v2/products", action = "api_products#index" },
+  }
+
+  local sorted = rails._sort_routes_by_api(routes)
+  -- First two should have /api in path
+  assert_truthy(sorted[1].path:find("/api"), "first route should have /api")
+  assert_truthy(sorted[2].path:find("/api"), "second route should have /api")
+  -- Last two should NOT have /api in path
+  assert_eq(sorted[3].path:find("/api"), nil, "third route should NOT have /api")
+  assert_eq(sorted[4].path:find("/api"), nil, "fourth route should NOT have /api")
 end)
 
 print("\n=== Rails Integration Tests Complete ===\n")

--- a/specs/issues/017-rails-grape-mounted-api.md
+++ b/specs/issues/017-rails-grape-mounted-api.md
@@ -1,0 +1,52 @@
+## **Status:**
+- Review: Approved
+- PR: Todo
+
+## Metadata
+- **Title:** Rails integration — Grape mounted API fallback
+- **Phase:** 6 — Integrations
+- **GitHub Issue:** #17
+
+---
+
+## Description
+Hỗ trợ app Rails có mounted Grape API, nơi `bin/rails routes` không phản ánh đầy đủ endpoint thực.
+
+- **Command chính:** `:Restman rails`.
+- **Problem:** nếu app dùng mounted API kiểu `mount Api::Base => "/"`, `:Restman rails` có thể chỉ thấy mount point hoặc route tổng quát, không đủ để picker toàn bộ endpoint con.
+- **Detect mounted Grape API:** scan `config/routes.rb` để tìm pattern `mount ... => ...` và dấu hiệu namespace/class của Grape API.
+- **Auto fallback:** khi detect Grape mount, `:Restman rails` sẽ dùng `bin/rails routes` và `bundle exec rake grape:routes` cùng nhau để build danh sách endpoint đầy đủ.
+- **Warning và degrade:** nếu Grape mount được phát hiện nhưng `bundle exec rake grape:routes` không khả dụng, `:Restman rails` vẫn fail gracefully và cảnh báo user rằng route list có thể incomplete.
+
+- **Scope v1:** `:Restman rails` detect được mounted Grape API, load được cả Rails routes và Grape routes cơ bản, rồi mở picker để user chọn route và gửi request như flow Rails hiện có.
+
+---
+
+## Spec Reference
+- Section: §7.1 `:Restman rails` trong [`story.md`](../story.md).
+
+---
+
+## Acceptance Criteria
+- [ ] Project có `mount Api::Base => "/"` trong `config/routes.rb` → `:Restman rails` tự động dùng `bundle exec rake grape:routes` bên cạnh `bin/rails routes`.
+- [ ] Project không có mounted Grape API → `:Restman rails` không chạy `bundle exec rake grape:routes` và không hiện warning Grape.
+- [ ] Nếu `bundle exec rake grape:routes` không thành công, `:Restman rails` vẫn fail gracefully và thông báo rõ ràng.
+- [ ] Picker format tương thích flow hiện tại: `VERB PATH handler`.
+- [ ] Chọn endpoint có dynamic params vẫn prompt và gửi request đúng URL resolved.
+- [ ] Không làm regress flow `:Restman rails` hiện tại cho Rails routes thường.
+
+---
+
+## Implementation Checklist
+- [ ] Mở rộng `lua/restman/integrations/rails.lua` hoặc tách module `lua/restman/integrations/rails_grape.lua`.
+- [ ] Helper detect Grape mount từ `config/routes.rb`.
+- [ ] Bổ sung auto-fallback loader để `:Restman rails` chạy `bundle exec rake grape:routes` khi cần.
+- [ ] Notify warning / degrade gracefully khi Grape route loader không khả dụng.
+- [ ] Implement loader/introspection cho endpoint Grape thay vì chỉ phụ thuộc `bin/rails routes`.
+- [ ] Reuse picker + send flow hiện có để chọn và gửi request.
+
+---
+
+## Notes
+- Depends on: 015 (Rails routes integration), 006 (dynamic params), 008 (env), 012 (picker), 013 (commands).
+- Cần tránh over-engineer parser Ruby AST ở v1; ưu tiên một cơ chế introspection ổn định và degrade rõ ràng nếu app structure không hỗ trợ.


### PR DESCRIPTION
- Add rails_grape.lua module to parse and cache Grape routes
- Detect mounted Grape APIs in Rails config/routes.rb
- Merge Grape routes with Rails routes, sorted by /api path prefix
- Add :Restman rails grape command with refresh capability
- Update config with grape_command, grape_cache_file, description_format

## Issue
closes #30 